### PR TITLE
fix bearer token

### DIFF
--- a/lib/csco-spark.js
+++ b/lib/csco-spark.js
@@ -11,7 +11,7 @@ function _reqOptions(options) {
     method: options.method,
     strictSSL: false
   };
-  if(options.token) opts.headers.Authorization = `Bearer ${options.token}`
+  if(options.token) opts.headers.Authorization = 'Bearer ' + options.token
   return opts;
 }
 


### PR DESCRIPTION
There seemed to be two issues, the first was that the quotes were backticks, and the second was that the ${} substitution was failing.  

node v5.3.0
